### PR TITLE
[Swift] Trailing closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Early feedback from @adamk, @domenic, @slightlyoff, @erights, @waldemarhowart, @
 Block Params
 =========
 
-This is a very early [stage 0](https://tc39.github.io/process-document/) exploration of a syntactical simplication (heavily inspired by [Kotlin](https://kotlinlang.org/docs/reference/type-safe-builders.html), [Ruby](#ruby) and [Groovy](http://docs.groovy-lang.org/docs/latest/html/documentation/core-domain-specific-languages.html)) that enables domain specific languages to be developed in userland.
+This is a very early [stage 0](https://tc39.github.io/process-document/) exploration of a syntactical simplication (heavily inspired by [Kotlin](https://kotlinlang.org/docs/reference/type-safe-builders.html), [Ruby](#ruby) [Groovy](http://docs.groovy-lang.org/docs/latest/html/documentation/core-domain-specific-languages.html)) and [Swift](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Closures.html#//apple_ref/doc/uid/TP40014097-CH11-ID102) that enables domain specific languages to be developed in userland.
 
 It is a syntactic simplification that allows, on function calls, to omit parantheses around the ***last***  parameter when that's a lambda.
 


### PR DESCRIPTION
https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Closures.html#//apple_ref/doc/uid/TP40014097-CH11-ID102

I love the Swift syntax for parameters in trailing closures and thought it'd be helpful to list it too:

```swift
let strings = numbers.map { n in
    return n**2
}
```